### PR TITLE
Faster EntityKind deserialization

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,11 @@
+name: "Check Scala CLA"
+on:
+  pull_request:
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify CLA
+        uses: scala/cla-checker@v1
+        with:
+          author: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
Split the string at the first colon rather than using regular expressions.

I'm using this on a large build unit. Loading the model was taking ~55 seconds--with this change it now takes 10 seconds.