### PR TITLE
drop Scala 2.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17, 21]
-        scala: [2.13.x, 2.12.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -21,4 +20,4 @@ jobs:
         java-version: ${{matrix.java}}
     - uses: sbt/setup-sbt@v1
     - name: Test
-      run: sbt ++${{matrix.scala}} test
+      run: sbt test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sculpt: dependency graph extraction for Scala 2
 
 Sculpt is a compiler plugin for analyzing the dependency structure of
-Scala 2 source code.
+Scala 2.13 source code.
 
 ## Project status
 
@@ -10,9 +10,6 @@ it as open source as a public service with the hopes the code will be
 useful to someone.
 
 Sculpt is NOT supported under the Akka subscription.
-
-Supported Scala versions are currently 2.13.x and 2.12.x.
-(2.12.x support is likely to be discontinued.)
 
 ## What is it for?
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,7 @@ licenses := Seq(
   "Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 homepage := Some(url("http://github.com/lightbend/scala-sculpt"))
 
-scalaVersion := crossScalaVersions.value.head
-crossScalaVersions := Seq("2.13.16", "2.12.20")
+scalaVersion := "2.13.16"
 
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",

--- a/src/test/scala/com/lightbend/tools/sculpt/IntegrationTest.scala
+++ b/src/test/scala/com/lightbend/tools/sculpt/IntegrationTest.scala
@@ -8,22 +8,10 @@ import scala.tools.nsc.{Global, Settings}
 
 object Scaffold {
 
-  val classes: String = {
-    // this will be e.g. "2.11" or "2.12"
-    val majorScalaVersion = {
-      val v = scala.util.Properties.versionNumberString
-      if (v matches ".*-(pre-\\w+|M\\d+|RC\\d+)") {
-        v
-      }
-      else {
-        v.split('.').take(2).mkString(".")
-      }
-    }
-    val relative = s"./target/scala-$majorScalaVersion/classes"
-    val file = new java.io.File(relative)
-    assert(file.exists)
-    file.getAbsolutePath
-  }
+  val classes: String =
+    new java.io.File("./target/scala-2.13/classes")
+      .ensuring(_.exists)
+      .getAbsolutePath
 
   def defaultSettings: Settings = {
     val settings = new Settings

--- a/src/test/scala/com/lightbend/tools/sculpt/Samples.scala
+++ b/src/test/scala/com/lightbend/tools/sculpt/Samples.scala
@@ -474,49 +474,45 @@ object Samples {
          |[0] tp:scala.AnyRef
          |""".stripMargin)
 
-  // test:runMain com.lightbend.tools.sculpt.Samples "pattern match" "object O { 0 match { case _ => () } }"
-  // we only run this on 2.13, because the results are different (and worse) on 2.12, as per
-  // https://github.com/lightbend/scala-sculpt/issues/28
-  if (!scala.util.Properties.versionNumberString.startsWith("2.12"))
-    Sample(
-      name = "pattern match",
-      source =
-        """|object O { 0 match { case _ => () } }""".stripMargin,
-      json =
-        """|[
-           |  {"extends": ["pkt:scala", "tp:AnyRef"], "sym": ["o:O"]},
-           |  {"sym": ["o:O", "def:<init>"], "uses": ["o:O"]},
-           |  {"sym": ["o:O", "def:<init>"], "uses": ["pkt:java", "pkt:lang", "cl:Object", "def:<init>"]}
-           |]""".stripMargin,
-      classJson =
-        """|[
-           |  {"sym": ["o:O"], "uses": ["pkt:java", "pkt:lang", "cl:Object"]},
-           |  {"sym": ["o:O"], "uses": ["pkt:scala", "tp:AnyRef"]}
-           |]""".stripMargin,
-      graph =
-        """|Graph 'pattern match': 4 nodes, 3 edges
-           |Nodes:
-           |  - o:O
-           |  - pkt:scala.tp:AnyRef
-           |  - o:O.def:<init>
-           |  - pkt:java.pkt:lang.cl:Object.def:<init>
-           |Edges:
-           |  - o:O -[Extends]-> pkt:scala.tp:AnyRef
-           |  - o:O.def:<init> -[Uses]-> o:O
-           |  - o:O.def:<init> -[Uses]-> pkt:java.pkt:lang.cl:Object.def:<init>""".stripMargin,
-      tree =
-        """|pattern match:
-           |└── O
-           |    └── scala.AnyRef
-           |└── scala.AnyRef
-           |""".stripMargin,
-      cycles =
-        """|""".stripMargin,
-      layers =
-        """|[1] o:O
-           |[0] cl:java.lang.Object
-           |[0] tp:scala.AnyRef
-           |""".stripMargin)
+  Sample(
+    name = "pattern match",
+    source =
+      """|object O { 0 match { case _ => () } }""".stripMargin,
+    json =
+      """|[
+         |  {"extends": ["pkt:scala", "tp:AnyRef"], "sym": ["o:O"]},
+         |  {"sym": ["o:O", "def:<init>"], "uses": ["o:O"]},
+         |  {"sym": ["o:O", "def:<init>"], "uses": ["pkt:java", "pkt:lang", "cl:Object", "def:<init>"]}
+         |]""".stripMargin,
+    classJson =
+      """|[
+         |  {"sym": ["o:O"], "uses": ["pkt:java", "pkt:lang", "cl:Object"]},
+         |  {"sym": ["o:O"], "uses": ["pkt:scala", "tp:AnyRef"]}
+         |]""".stripMargin,
+    graph =
+      """|Graph 'pattern match': 4 nodes, 3 edges
+         |Nodes:
+         |  - o:O
+         |  - pkt:scala.tp:AnyRef
+         |  - o:O.def:<init>
+         |  - pkt:java.pkt:lang.cl:Object.def:<init>
+         |Edges:
+         |  - o:O -[Extends]-> pkt:scala.tp:AnyRef
+         |  - o:O.def:<init> -[Uses]-> o:O
+         |  - o:O.def:<init> -[Uses]-> pkt:java.pkt:lang.cl:Object.def:<init>""".stripMargin,
+    tree =
+      """|pattern match:
+         |└── O
+         |    └── scala.AnyRef
+         |└── scala.AnyRef
+         |""".stripMargin,
+    cycles =
+      """|""".stripMargin,
+    layers =
+      """|[1] o:O
+         |[0] cl:java.lang.Object
+         |[0] tp:scala.AnyRef
+         |""".stripMargin)
 
   // this is the sample in the readme
   // test:runMain com.lightbend.tools.sculpt.Samples "readme" "object Dep1 { val x = 42; val y = Dep2.z }; object Dep2 { val z = Dep1.x }"


### PR DESCRIPTION
it's time, I think. (this was originally built for a customer for use on 2.12, but that customer has since moved to 2.13)

@jackkoenig unless you're using it on 2.12? in which case I wouldn't mind leaving this in place. keeping 2.12 isn't causing trouble, exactly, I'd just like to keep the repo easy to keep up to date and easy to work on, even though little work is currently happening